### PR TITLE
Don't remove URL query parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 dist
 *.egg-info
+*.pyc

--- a/amazonify.py
+++ b/amazonify.py
@@ -1,7 +1,8 @@
 """The simplest way to build Amazon Affiliate links, in Python."""
 
 
-from urlparse import urlparse, urlunparse
+from urlparse import urlparse, urlunparse, parse_qs
+from urllib import urlencode
 
 
 def amazonify(url, affiliate_tag):
@@ -27,9 +28,10 @@ def amazonify(url, affiliate_tag):
     if not new_url.netloc:
         return None
 
-    # Replace the original querystrings with our affiliate tag. Since all
-    # Amazon querystrings have no useful purpose, we can safely remove them and
-    # only add our affiliate tag.
-    new_url = new_url[:4] + ('tag=%s' % affiliate_tag,) + new_url[5:]
+    # Add or replace the original affiliate tag with our affiliate tag in the
+    # querystring. Leave everything else unchanged.
+    query_dict = parse_qs(new_url[4])
+    query_dict['tag'] = affiliate_tag
+    new_url = new_url[:4] + (urlencode(query_dict, True), ) + new_url[5:]
 
     return urlunparse(new_url)

--- a/tests.py
+++ b/tests.py
@@ -28,7 +28,7 @@ class Amazonify(TestCase):
     def test_adds_affiliate_tag_as_a_querystring(self):
         # Test it on a URL that already has a querystring:
         test_url = amazonify('http://www.amazon.com/PostgreSQL-High-Performance-Gregory-Smith/dp/184951030X/ref=trdrt_tipp_dp_img_GWTB_507846?pf_rd_p=1367759962&pf_rd_s=right-4&pf_rd_t=101&pf_rd_i=507846&pf_rd_m=ATVPDKIKX0DER&pf_rd_r=1216X6HJC7KEWY0X3VD7', 'rdegges-20')
-        self.assertEqual(urlparse(test_url).query, 'tag=rdegges-20')
+        self.assertNotEqual(-1, urlparse(test_url).query.find('tag=rdegges-20'))
 
         # Test it on a URL that has no querystring:
         test_url = amazonify('http://www.amazon.com/PostgreSQL-High-Performance-Gregory-Smith/dp/184951030X/ref=trdrt_tipp_dp_img_GWTB_507846', 'rdegges-20')
@@ -48,3 +48,10 @@ class Amazonify(TestCase):
 
         test_url = amazonify('http://www.amazon.co.uk/PostgreSQL-High-Performance-Gregory-Smith/dp/184951030X/ref=trdrt_tipp_dp_img_GWTB_507846', 'rdegges-20')
         self.assertEqual(urlparse(test_url).netloc, 'www.amazon.co.uk')
+
+    def test_promo_url_has_query_params(self):
+        # test a URL that contains mandatory query params
+        test_url = amazonify('http://www.amazon.co.uk/gp/feature.html?docId=1000577623&ie=UTF8', 'rdegges-20')
+        qs = urlparse(test_url).query
+        self.assertNotEqual(-1, qs.find('tag=rdegges-20'))
+        self.assertNotEqual(-1, qs.find('docId=1000577623'))


### PR DESCRIPTION
Instead of removing query parameters, add or overwrite tag parameter, see issue #3.
